### PR TITLE
remove cross-build check and check before is_apple_os

### DIFF
--- a/recipes/glib/all/conanfile.py
+++ b/recipes/glib/all/conanfile.py
@@ -93,12 +93,10 @@ class GLibConan(ConanFile):
             # for Linux, gettext is provided by libc
             self.requires("libgettext/0.21")
 
-        if is_apple_os(self.settings.os):
+        if self.settings.os == "Macos" and is_apple_os(self.settings.os):
             self.requires("libiconv/1.17")
 
     def validate(self):
-        if hasattr(self, 'settings_build') and cross_building(self, skip_x64_x86=True):
-            raise ConanInvalidConfiguration("Cross-building not implemented")
         if Version(self.version) >= "2.69.0" and not self.options.with_pcre:
             raise ConanInvalidConfiguration("option glib:with_pcre must be True for glib >= 2.69.0")
         if self.settings.os == "Windows" and not self.options.shared and Version(self.version) < "2.71.1":
@@ -121,7 +119,7 @@ class GLibConan(ConanFile):
         self.folders.source = self._source_subfolder
 
     def generate(self):
-        if is_apple_os(self.settings.os):
+        if self.settings.os == "Macos" and is_apple_os(self.settings.os):
             self.conf["tools.apple:sdk_path"] = apple_sdk_path(self)
 
         tc = PkgConfigDeps(self)
@@ -141,7 +139,7 @@ class GLibConan(ConanFile):
         tc = MesonToolchain(self)
 
         defs = dict()
-        if is_apple_os(self.settings.os):
+        if self.settings.os == "Macos" and is_apple_os(self.settings.os):
             defs["iconv"] = "external"  # https://gitlab.gnome.org/GNOME/glib/issues/1557
         defs["selinux"] = "enabled" if self.options.get_safe("with_selinux") else "disabled"
         defs["libmount"] = "enabled" if self.options.get_safe("with_mount") else "disabled"

--- a/recipes/glib/all/test_package/conanfile.py
+++ b/recipes/glib/all/test_package/conanfile.py
@@ -6,6 +6,9 @@ class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi", "pkg_config"
 
+    def build_requirements(self):
+        self.build_requires("pkgconf/1.7.4")
+
     def build(self):
         if self.settings.os != "Windows":
             with tools.environment_append({'PKG_CONFIG_PATH': "."}):


### PR DESCRIPTION
Add checks to is_apple_os due to https://github.com/conan-io/conan-center-index/issues/12334
and https://github.com/conan-io/conan-center-index/pull/12335

Specify library name and version:  **lib/1.0**

- [ ] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [ ] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [ ] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [ ] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
